### PR TITLE
Fix UTF-8 decoding for AirPlay receiver names

### DIFF
--- a/bin/omarchy-airplay-ctl
+++ b/bin/omarchy-airplay-ctl
@@ -32,10 +32,11 @@ def clean(s,n):return "".join(c if c>=" " and c not in "\t\n\r" else " " for c i
 def decode_avahi_name(s):
  b=bytearray(); i=0
  while i<len(s):
-  if s[i:i+1]=="\\" and i+3<len(s) and re.fullmatch(r"[0-7]{3}",s[i+1:i+4]):
-   b.append(int(s[i+1:i+4],8)); i+=4
-  else:
-   b.extend(s[i].encode("utf-8")); i+=1
+  if s[i:i+1]=="\\" and i+3<len(s) and re.fullmatch(r"[0-9]{3}",s[i+1:i+4]):
+   value=int(s[i+1:i+4])
+   if value<=255:
+    b.append(value); i+=4; continue
+  b.extend(s[i].encode("utf-8")); i+=1
  return b.decode("utf-8","replace")
 def creds():
  try:d=dfd("doubletake")

--- a/bin/omarchy-airplay-ctl
+++ b/bin/omarchy-airplay-ctl
@@ -29,6 +29,14 @@ def write(d,n,z):
  finally:os.close(f)
  os.replace(t,n,src_dir_fd=d,dst_dir_fd=d);os.fsync(d)
 def clean(s,n):return "".join(c if c>=" " and c not in "\t\n\r" else " " for c in s)[:n].strip()
+def decode_avahi_name(s):
+ b=bytearray(); i=0
+ while i<len(s):
+  if s[i:i+1]=="\\" and i+3<len(s) and re.fullmatch(r"[0-7]{3}",s[i+1:i+4]):
+   b.append(int(s[i+1:i+4],8)); i+=4
+  else:
+   b.extend(s[i].encode("utf-8")); i+=1
+ return b.decode("utf-8","replace")
 def creds():
  try:d=dfd("doubletake")
  except FileNotFoundError:return {}
@@ -62,7 +70,7 @@ def discovery():
   try:a=str(ipaddress.IPv4Address(f[7]))
   except ValueError:continue
   if a in seen:continue
-  name=clean(re.sub(r"\\(\d{3})",lambda m:chr(int(m.group(1))),f[3]),NAMES) or a
+  name=clean(decode_avahi_name(f[3]),NAMES) or a
   m=re.search(r"(?:^|,)deviceid=([0-9A-Fa-f:]+)",f[9]); i=m.group(1) if m and IDS.fullmatch(m.group(1)) else ""
   print(f"{name}\t{a}\t{i}\t{int(i in c)}");seen.add(a)
   if len(seen)==32:return


### PR DESCRIPTION
Avahi's parsable output encodes non-ASCII characters as three-digit decimal byte escapes. Decode those bytes as UTF-8 before displaying receiver names, so names such as `Alan’s MacBook Pro` render correctly instead of becoming mojibake.

Validated on Omarchy with AirPlay receivers discovered through Avahi. The decoder also passes focused cases for curly apostrophes, bracketed TV names, accented characters, and plain ASCII names.